### PR TITLE
Issue 31: fix cdf function and add test

### DIFF
--- a/src/PrimaryCensoredDist.jl
+++ b/src/PrimaryCensoredDist.jl
@@ -73,7 +73,7 @@ function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
         return exp(logcdf(d.uncensored, u) + logpdf(d.censoring, x - u))
     end
 
-    domain = (max(x - maximum(d.censoring), 0.), max(x - minimum(d.censoring), 0.))
+    domain = (max(x - maximum(d.censoring), 0.0), max(x - minimum(d.censoring), 0.0))
 
     if domain[2] - domain[1] ≈ 0.0
         return 0.0

--- a/src/PrimaryCensoredDist.jl
+++ b/src/PrimaryCensoredDist.jl
@@ -64,18 +64,23 @@ end
 Base.eltype(::Type{<:PrimaryCensoredDist{D}}) where {D} = promote_type(eltype(D), eltype(D))
 
 function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
-    if x <= 0
-        return 0
+    solver = QuadGKJL()
+    if x <= minimum(d.censoring)
+        return 0.
     end
 
     function f(u, x)
-        return exp(logcdf(d.uncensored, x) + logpdf(d.censoring, x - u))
+        return exp(logcdf(d.uncensored, x - u) + logpdf(d.censoring, u))
     end
 
-    domain = (max(1e-6, x - maximum(d.censoring)), x)
+    domain = (min(minimum(d.censoring), x), min(maximum(d.censoring), x))
+    if domain[2] - domain[1] ≈ 0.
+        return 0.
+    end
+
     prob = IntegralProblem(f, domain, x)
-    result = solve(prob, QuadGKJL())[1]
-    return (result)
+    result = solve(prob, solver)[1]
+    return result
 end
 
 function Distributions.logcdf(d::PrimaryCensoredDist, x::Real)

--- a/src/PrimaryCensoredDist.jl
+++ b/src/PrimaryCensoredDist.jl
@@ -70,10 +70,11 @@ function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
     end
 
     function f(u, x)
-        return exp(logcdf(d.uncensored, x - u) + logpdf(d.censoring, u))
+        return exp(logcdf(d.uncensored, u) + logpdf(d.censoring, x - u))
     end
 
-    domain = (min(minimum(d.censoring), x), min(maximum(d.censoring), x))
+    domain = (max(x - maximum(d.censoring), 0.), max(x - minimum(d.censoring), 0.))
+
     if domain[2] - domain[1] ≈ 0.0
         return 0.0
     end

--- a/src/PrimaryCensoredDist.jl
+++ b/src/PrimaryCensoredDist.jl
@@ -66,7 +66,7 @@ Base.eltype(::Type{<:PrimaryCensoredDist{D}}) where {D} = promote_type(eltype(D)
 function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
     solver = QuadGKJL()
     if x <= minimum(d.censoring)
-        return 0.
+        return 0.0
     end
 
     function f(u, x)
@@ -74,8 +74,8 @@ function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
     end
 
     domain = (min(minimum(d.censoring), x), min(maximum(d.censoring), x))
-    if domain[2] - domain[1] ≈ 0.
-        return 0.
+    if domain[2] - domain[1] ≈ 0.0
+        return 0.0
     end
 
     prob = IntegralProblem(f, domain, x)

--- a/src/PrimaryCensoredDist.jl
+++ b/src/PrimaryCensoredDist.jl
@@ -64,7 +64,6 @@ end
 Base.eltype(::Type{<:PrimaryCensoredDist{D}}) where {D} = promote_type(eltype(D), eltype(D))
 
 function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
-    solver = QuadGKJL()
     if x <= minimum(d.censoring)
         return 0.0
     end
@@ -80,7 +79,7 @@ function Distributions.cdf(d::PrimaryCensoredDist, x::Real)
     end
 
     prob = IntegralProblem(f, domain, x)
-    result = solve(prob, solver)[1]
+    result = solve(prob, QuadGKJL())[1]
     return result
 end
 

--- a/test/PrimaryCensoredDist.jl
+++ b/test/PrimaryCensoredDist.jl
@@ -57,7 +57,7 @@ end
         calc_cdf = map(0:10) do t
             cdf(use_dist, t)
         end
-        @test expected_cdf≈calc_cdf
+        @test expected_cdf ≈ calc_cdf
     end
 end
 

--- a/test/PrimaryCensoredDist.jl
+++ b/test/PrimaryCensoredDist.jl
@@ -39,9 +39,26 @@ end
 
 @testitem "Test cdf method" begin
     using Distributions
-    use_dist = primarycensored(LogNormal(3.5, 1.5), Uniform(1, 2))
-    @test cdf(use_dist, 1e8) ≈ 1.0
-    @test logcdf(use_dist, -Inf) ≈ -Inf
+    @testset "Constructor and end point" begin
+        use_dist = primarycensored(LogNormal(3.5, 1.5), Uniform(1, 2))
+        @test cdf(use_dist, 1e8) ≈ 1.0
+        @test logcdf(use_dist, -Inf) ≈ -Inf
+    end
+
+    @testset "Check CDF function against known Exp(1) with uniform censor on primary" begin
+        dist = Exponential(1.0)
+        use_dist = primarycensored(dist, Uniform(0, 1))
+        # Analytical solution for the pmf of observation in [0,1], [1,2], ...
+        expected_pmf_uncond = [exp(-1)
+                               [(1 - exp(-1)) * (exp(1) - 1) * exp(-s) for s in 1:9]]
+        # Analytical solution for the cdf
+        expected_cdf = [0.0; cumsum(expected_pmf_uncond)]
+        # Calculated cdf
+        calc_cdf = map(0:10) do t
+            cdf(use_dist, t)
+        end
+        @test expected_cdf≈calc_cdf
+    end
 end
 
 @testitem "Test ccdf" begin


### PR DESCRIPTION
This PR closes #31 

Its a rewrite of the `cdf` function to do the convolution representation of the censored cdf correctly.

NB: 
- The behaviour of `rand` suggests that the minimum value is `minimum(d.censoring)` and this is written to reflect that. A test is added against a delay distribution of `Exp(1)` with `Uniform(0,1)` primary censoring distribution. This is analytically solvable and used in `EpiAware` test suite (see #31 for link to this).
~I've swapped the integrand order. For convolutions these are interchangeable, however in this case it informs `domain` limits. We can order them in the same way as https://github.com/epinowcast/primarycensoreddist/blob/b84867cac0ffee7284f809f77946d0f3e4001bed/inst/stan/functions/primary_censored_dist.stan#L91 but would need to change the domain limits.~
~I've added `solver = QuadGKJL()`. This is suggestive towards having flexibility in choosing numerical quadrature algo, but this is out of scope for solving this issue.~

Strikethough text above no longer in PR.