### PR TITLE
Issue 38: Update fitting vignette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ dev/
 
 # Helpers
 justfile
+docs/src/getting-started/tutorials/fitting-dists-with-Turing.md

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,10 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PairPlots = "43a3c2be-4208-490b-832a-a21dcd55d7da"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 PrimaryCensored = "b2eeebe4-5992-4301-9193-7ebc9f62c855"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -8,7 +8,7 @@ getting_started_pages = Any[
     ],
     "Tutorials" => [
         "Overview" => "getting-started/tutorials/index.md",
-        "Fitting distributions with PrimaryCensored and Turing" => "getting-started/tutorials/fitting-dists-with-Turing.md",
+        "Fitting distributions with PrimaryCensored and Turing" => "getting-started/tutorials/fitting-dists-with-Turing.md"
     ]
 ]
 

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -7,7 +7,8 @@ getting_started_pages = Any[
         "Overview" => "getting-started/explainers/index.md"
     ],
     "Tutorials" => [
-        "Overview" => "getting-started/tutorials/index.md"
+        "Overview" => "getting-started/tutorials/index.md",
+        "Fitting distributions with PrimaryCensored and Turing" => "getting-started/tutorials/fitting-dists-with-Turing.md",
     ]
 ]
 

--- a/docs/src/getting-started/fitting-dists-with-Turing.jl
+++ b/docs/src/getting-started/fitting-dists-with-Turing.jl
@@ -17,11 +17,11 @@ end
 
 # ╔═╡ 3690c122-d630-4fd0-aaf2-aea9226df086
 begin
-    using DataFrames
+    using DataFramesMeta
     using Turing
     using Distributions
     using Random
-    using CairoMakie
+    using CairoMakie, PairPlots
     using StatsBase
     using PrimaryCensored
 end
@@ -50,28 +50,6 @@ This vignette builds on the concepts introduced in the [Getting Started with Pri
 We use CairoMakie for plotting, Turing for probabilistic programming, and the _classics_ DataFrames, Random, StatsBase (for the ecdf function). We install the PrimaryCensored.jl packages from the github repo.
 """
 
-# ╔═╡ 80ce4590-e51a-457c-8497-d16916688656
-
-# ╔═╡ 320f081c-b26e-495a-9887-56c4212d1ed7
-
-# ╔═╡ 960b18ef-ab1d-417f-853e-d05d2cddc78f
-# FIXME: PrimaryCensored.jl installation
-
-# ╔═╡ 932b1cac-1705-43fb-bdae-91b97e39aef3
-#Pkg.activate(temp = true)
-
-# ╔═╡ b84fe36a-e673-48a6-a57f-c534608ae9bb
-#Pkg.add(url = "https://github.com/epinowcast/PrimaryCensored.jl", rev = "main")
-
-# ╔═╡ 842769b4-a499-41f6-baf1-3b54f14262d4
-#using PrimaryCensored
-
-# ╔═╡ 8c77f9db-72a7-4a09-88fa-ac3fea030f84
-# CairoMakie.activate!(type = "svg")  # necessary ?
-
-# ╔═╡ cb58eb18-aabb-4daf-94dc-a4b101791fdd
-# CairoMakie.inline!(true) # necessary ?
-
 # ╔═╡ c5ec0d58-ce3d-4b0b-a261-dbd37b119f71
 md"""
 # Simulating censored and truncated delay distribution data
@@ -94,6 +72,9 @@ meanlog = 1.5
 # ╔═╡ 54700ad7-6b2a-440f-903a-c126b4c60c0e
 sdlog = 0.75
 
+# ╔═╡ aabd7db4-103a-4029-96d3-0de7077d759d
+true_dist = LogNormal(meanlog, sdlog)
+
 # ╔═╡ 767a58ed-9d7b-41db-a488-10f98a777474
 md"we generate varying pwindow, swindow, and obs_time lengths"
 
@@ -107,48 +88,55 @@ swindows = rand(1:2, n)
 obs_times = rand(8:10, n)
 
 # ╔═╡ 2e04be98-625f-45f4-bf5e-a0074ea1ea01
-md"Let's generates all the $n$ samples:"
+md"Let's generates all the $n$ samples by recreating the primary censored sampling function from `primarycensoreddist`, c.f. documentation [here](https://primarycensoreddist.epinowcast.org/reference/rprimarycensoreddist.html)."
 
-# ╔═╡ a063cf93-9cd2-4c8b-9c0d-87075d1fa20d
-samples = Vector{Int64}(undef, n);
+# ╔═╡ 987c9e27-b993-4aae-a25e-2a12ffe94ee7
+"""
+	function rpcens(dist; pwindow = 1, swindow = 1, D = Inf, max_tries = 1000)
 
-# ╔═╡ 51f266ce-ffca-4ffe-aae5-ab0fa0e16479
-for i in 1:n
-    primarycensored_dist = primarycensored(
-        LogNormal(meanlog, sdlog), Uniform(0, pwindows[i]))
-    trunc_primarycensored_dist = truncated(primarycensored_dist, 0, obs_times[i])
+Does a truncated censored sample from `dist` with a uniform primary time on `[0, pwindow]`.
+"""
+function rpcens(dist; pwindow = 1, swindow = 1, D = Inf, max_tries = 1000)
+    T = zero(eltype(dist))
+    invalid_sample = true
+    attempts = 1
+    while (invalid_sample && attempts <= max_tries)
+        X = rand(dist)
+        U = rand() * pwindow
+        T = X + U
+        attempts += 1
+        if X + U < D
+            invalid_sample = false
+        end
+    end
 
-    # make it within range, normally using truncated here. FIXME
-    #trc_evt = min(rand(d), )
-    samples[i] = (floor(rand(trunc_primarycensored_dist)) / swindows[i]) * swindows[i]
+    @assert !invalid_sample "censored value not found in $max_tries attempts"
+
+    return (T ÷ swindow) * swindow
 end
 
-# ╔═╡ 8ea6883e-f157-4faf-9409-f91dd2581464
-samples
+# ╔═╡ a063cf93-9cd2-4c8b-9c0d-87075d1fa20d
+samples = map(pwindows, swindows, obs_times) do pw, sw, ot
+    rpcens(true_dist; pwindow = pw, swindow = sw, D = ot)
+end
 
 # ╔═╡ 50757759-9ec3-42d0-a765-df212642885a
-md"Create a dataframe with the data we just generated"
+md"Create a dataframe with the data we just generated aggregated to unique combinations and count occurrences.
+"
 
 # ╔═╡ 5aed77d3-5798-4538-b3eb-3f4ce43d0423
-delay_data = DataFrame(
-    pwindow = pwindows,
-    obs_time = obs_times,
-    observed_delay = samples,
-    observed_delay_upper = [min(obs_times[i], samples[i] + swindows[i]) for i in 1:n]
-)
-
-# ╔═╡ 06d2d1a0-883f-4f79-b94d-e4c94647e208
-first(delay_data, 6)
-
-# ╔═╡ bfef454d-3664-49de-b8ae-10c529f5a64b
-md"Aggregate to unique combinations and count occurrences"
-
-# ╔═╡ cd9e4e56-301d-44b8-b013-9cf9196e7e90
-
-# ╔═╡ 181e3bbd-d95b-4c50-87a9-75f4851e85a1
-delay_counts = combine(
-    groupby(delay_data, [:pwindow, :obs_time, :observed_delay, :observed_delay_upper]),
-    nrow => :n)
+delay_counts = mapreduce(vcat, pwindows, swindows, obs_times, samples) do pw, sw, ot, s
+    DataFrame(
+        pwindow = pw,
+        swindow = sw,
+        obs_time = ot,
+        observed_delay = s,
+        observed_delay_upper = s + sw
+    )
+end |>
+               df -> @groupby(df, :pwindow, :swindow, :obs_time, :observed_delay,
+    :observed_delay_upper) |>
+                     gd -> @combine(gd, :n=length(:pwindow))
 
 # ╔═╡ 993f1f74-4a55-47a7-9e3e-c725cba13c0a
 md"""
@@ -158,50 +146,41 @@ Compare the samples with and without secondary censoring to the true distributio
 # ╔═╡ 5a6d605d-bff6-4b7d-97f0-ca35750411d3
 empirical_cdf = ecdf(samples)
 
+# ╔═╡ ccd8dd8e-c361-43ba-b4f1-2444ec6008fc
+empirical_cdf_obs = ecdf(delay_counts.observed_delay, weights = delay_counts.n)
+
 # ╔═╡ 2b773594-5187-45bc-96f4-22a3d726b7d2
 # Create a sequence of x values for the theoretical CDF
 x_seq = range(minimum(samples), stop = maximum(samples), length = 100)
 
 # ╔═╡ a5b04acc-acc5-4d4d-8871-09d54caab185
-# Calculate theoretical CDF using log-normal distribution
-theoretical_cdf = cdf.(LogNormal(meanlog, sdlog), x_seq)
-
-# ╔═╡ 425cdd47-c69f-4bd8-9582-97fe6433891c
-# Create a long format DataFrame for plotting
-cdf_data = DataFrame(
-    x = vcat(x_seq, x_seq),
-    probability = vcat(empirical_cdf.(x_seq), theoretical_cdf),
-    type = repeat(["Observed", "Theoretical"], inner = length(x_seq))
-)
+# Calculate theoretical CDF using true log-normal distribution
+theoretical_cdf = x_seq |> x -> cdf(true_dist, x)
 
 # ╔═╡ fb6dc898-21a9-4f8d-aa14-5b45974c2242
-begin
-    # Plot using CairoMakie
-    fig = Figure(size = (800, 600))
+let
+    f = Figure()
+    ax = Axis(f[1, 1],
+        title = "Comparison of Observed vs Theoretical CDF",
+        ylabel = "Cumulative Probability",
+        xlabel = "Delay"
+    )
+    scatter!(
+        ax,
+        x_seq,
+        empirical_cdf_obs,
+        label = "Empirical CDF",
+        color = :blue        # linewidth = 2,
+    )
+    lines!(ax, x_seq, theoretical_cdf, label = "Theoretical CDF",
+        color = :black, linewidth = 2)
+    vlines!(ax, [mean(samples)], color = :blue, linestyle = :dash,
+        label = "Empirical mean", linewidth = 2)
+    vlines!(ax, [mean(true_dist)], linestyle = :dash,
+        label = "Theoretical mean", color = :black, linewidth = 2)
+    axislegend(position = :rb)
 
-    ax = Axis(fig[1, 1], title = "Comparison of Observed vs Theoretical CDF",
-        xlabel = "Delay", ylabel = "Cumulative Probability", titlealign = :center)
-
-    # Plot the empirical and theoretical CDF
-    lines!(ax, cdf_data.x[1:100], cdf_data.probability[1:100],
-        color = :dodgerblue, linewidth = 2, label = "Observed")
-    lines!(ax, cdf_data.x[101:end], cdf_data.probability[101:end],
-        color = :black, linewidth = 2, label = "Theoretical")
-
-    # Add vertical dashed lines for observed and theoretical means
-    mean_observed = mean(samples)
-    mean_theoretical = exp(meanlog + sdlog^2 / 2)
-
-    vlines!(ax, [mean_observed], color = :dodgerblue, linestyle = :dash,
-        linewidth = 1.5, label = "Mean Observed")
-    vlines!(ax, [mean_theoretical], color = :black, linestyle = :dash,
-        linewidth = 1.5, label = "Mean Theoretical")
-
-    # Customize the legend and appearance
-    axislegend(ax, position = :rb)
-
-    # Show the plot
-    fig
+    f
 end
 
 # ╔═╡ 9c8aebbe-8606-41e7-8e86-23129b1cbc8d
@@ -210,85 +189,176 @@ We've aggregated the data to unique combinations of `pwindow`, `swindow`, and `o
 """
 
 # ╔═╡ 91279812-9848-48bc-9258-b6f86c9fe923
-md"""
-Fitting a naive model using Turing.jl
+md"
+## Fitting a naive model using Turing
 
-We'll start by fitting a naive model using Turing.jl. We'll use the `Turing.jl` package to interface with Turing.jl. We define the model in a string and then write it to a file as in the [How to use primarycensoreddist with Stan](using-stan-tools.html) vignette.
-"""
-
-# ╔═╡ d995059c-81f7-441c-8695-6ba08c90a1f8
-N = nrow(delay_counts)
-
-# ╔═╡ a59d820c-616d-42ff-a0b3-d495d9f529f8
-y = delay_counts.observed_delay .+ 1e-6  # Adding small constant to avoid log(0)
+We'll start by fitting a naive model using NUTS from `Turing`. We define the model in the `Turing` PPL.
+"
 
 # ╔═╡ a257ce07-efbe-45e1-a8b0-ada40c29de8d
-@model naive_model(; y, n, N) = begin
-    # Priors
-    mu ~ Normal(1, 1)
-    sigma ~ truncated(Normal(0.5, 1), 0, Inf)
+@model function naive_model(N, y, n)
+    mu ~ Normal(1.0, 1.0)
+    sigma ~ truncated(Normal(0.5, 1.0); lower = 0.0)
+    d = LogNormal(mu, sigma)
 
-    # Likelihood
-    for i in 1:N
-        Turing.@addlogprob! n[i] * logpdf(LogNormal(mu, sigma), y[i])
+    for i in eachindex(y)
+        Turing.@addlogprob! n[i] * logpdf(d, y[i])
     end
 end
 
 # ╔═╡ 49846128-379c-4c3b-9ec1-567ffa92e079
+md"
+Now lets instantiate this model with data
+"
 
 # ╔═╡ 4cf596f1-0042-4990-8d0a-caa8ba1db0c7
-model = naive_model(y = y, n = delay_counts.n, N = nrow(delay_counts))
+naive_mdl = naive_model(
+    size(delay_counts, 1),
+    delay_counts.observed_delay .+ 1e-6, # Add a small constant to avoid log(0)
+    delay_counts.n)
 
-# ╔═╡ 5700a6c2-d6b1-4506-b776-7ba485262030
-chain = sample(model, NUTS(0.65), 4000; chains = 4)
+# ╔═╡ 71900c43-9f52-474d-adc7-becdc74045da
+md"
+and now let's fit the compiled model.
+"
 
-# ╔═╡ ac3407d6-26ed-4aa4-a7c9-40c529205915
-describe(chain)
+# ╔═╡ cd26da77-02fb-4b65-bd7b-88060d0c97e8
+naive_fit = sample(naive_mdl, NUTS(), MCMCThreads(), 500, 4)
+
+# ╔═╡ 10278d0c-8c72-4c5f-b857-d3bc6ff2c242
+summarize(naive_fit)
+
+# ╔═╡ 2c0b4f97-5953-497d-bca9-d1aa46c5150b
+let
+    f = pairplot(naive_fit)
+    vlines!(f[1, 1], [meanlog], linewidth = 4)
+    vlines!(f[2, 2], [sdlog], linewidth = 4)
+    f
+end
+
+# ╔═╡ 7122bd53-81f6-4ea5-a024-86fdd7a7207a
+md"
+We see that the model has converged and the diagnostics look good. However, just from the model posterior summary we see that we might not be very happy with the fit. `mu` is smaller than the target $(meanlog) and `sigma` is larger than the target $(sdlog).
+"
+
+# ╔═╡ 080c1bca-afcd-46c0-80b8-1708e8d05ae6
+md"
+## Fitting an improved model using censoring utilities
+
+We'll now fit an improved model by defining our observations as _censored_ using `PrimaryCensored.primarycensored` to construct censored delay distributions from actual delay distributions (which we sample below as `dist`) and uniform primary censored windows (which vary across the data).
+
+Using this approach we can write a log-pmf function `primary_censored_dist_lpmf` that accounts for:
+- The primary and secondary censoring windows, which can vary in length.
+- The effect of right truncation in biasing our observations.
+
+This is the analogous function to the function of the same name in [`primarycensored`](https://primarycensored.epinowcast.org/stan/primarycensored_8stan.html#a40c8992ec6549888fdd011beddf024b0): it calculates the log-probability of the secondary event occurring in the secondary censoring window conditional on the primary event occurring in the primary censoring window by calculating the increase in the CDF over the secondary window and rescaling by the probability of the secondary event occuring within the maximum observation time `D`.
+"
+
+# ╔═╡ f26f6b6b-27f5-4372-b214-d1515c8c0ddc
+function primarycensored_lpmf(dist, y, pwindow, y_upper, D)
+    censoreddist = primarycensored(dist, Uniform(0.0, pwindow))
+    return log(cdf(censoreddist, y_upper) - cdf(censoreddist, y)) -
+           log(cdf(censoreddist, D))
+end
+
+# ╔═╡ e24c231a-0bf3-4a03-a307-2ab43cdbecf4
+md"
+We make a new `Turing` model that now uses `primary_censored_dist_lpmf` rather than the naive uncensored and untruncated `logpdf`.
+"
+
+# ╔═╡ 21ffd833-428f-488d-8df3-e8468aa76bb6
+@model function primarycensoreddist_model(y, y_upper, n, pws, Ds)
+    mu ~ Normal(1.0, 1.0)
+    sigma ~ truncated(Normal(0.5, 0.5); lower = 0.0)
+    dist = LogNormal(mu, sigma)
+
+    for i in eachindex(y)
+        Turing.@addlogprob! n[i] * primarycensored_lpmf(
+            dist, y[i], pws[i], y_upper[i], Ds[i])
+    end
+end
+
+# ╔═╡ dfaab7c1-84be-421d-9eb3-60235a2b2a17
+md"
+Lets instantiate this model with data
+"
+
+# ╔═╡ a59e371a-b671-4648-984d-7bcaac367d32
+primarycensoreddist_mdl = primarycensoreddist_model(
+    delay_counts.observed_delay,
+    delay_counts.observed_delay_upper,
+    delay_counts.n,
+    delay_counts.pwindow,
+    delay_counts.obs_time
+)
+
+# ╔═╡ d26e224a-dc89-407d-9451-6665321154a2
+md"Now let’s fit the compiled model."
+
+# ╔═╡ b5cd8b13-e3db-4ed1-80ce-e3ac1c57932c
+primarycensoreddist_fit = sample(
+    primarycensoreddist_mdl, NUTS(), MCMCThreads(), 1000, 4)
+
+# ╔═╡ a53a78b3-dcbe-4b62-a336-a26e647dc8c8
+summarize(primarycensoreddist_fit)
+
+# ╔═╡ f0c02e4a-c0cc-41de-b1bf-f5fad7e7dfdb
+let
+    f = pairplot(primarycensoreddist_fit)
+    CairoMakie.vlines!(f[1, 1], [meanlog], linewidth = 3)
+    CairoMakie.vlines!(f[2, 2], [sdlog], linewidth = 3)
+    f
+end
+
+# ╔═╡ c045caa6-a44d-4a54-b122-1e50b1e0fe75
+md"
+We see that the model has converged and the diagnostics look good. We also see that the posterior means are very near the true parameters and the 90% credible intervals include the true parameters.
+"
 
 # ╔═╡ Cell order:
-# ╠═30511a27-984e-40b7-9b1e-34bc87cb8d56
-# ╠═bb9c75db-6638-48fe-afcb-e78c4bcc057d
+# ╟─30511a27-984e-40b7-9b1e-34bc87cb8d56
+# ╟─bb9c75db-6638-48fe-afcb-e78c4bcc057d
 # ╠═3690c122-d630-4fd0-aaf2-aea9226df086
-# ╠═80ce4590-e51a-457c-8497-d16916688656
-# ╠═320f081c-b26e-495a-9887-56c4212d1ed7
-# ╠═960b18ef-ab1d-417f-853e-d05d2cddc78f
-# ╠═932b1cac-1705-43fb-bdae-91b97e39aef3
-# ╠═b84fe36a-e673-48a6-a57f-c534608ae9bb
-# ╠═842769b4-a499-41f6-baf1-3b54f14262d4
-# ╠═8c77f9db-72a7-4a09-88fa-ac3fea030f84
-# ╠═cb58eb18-aabb-4daf-94dc-a4b101791fdd
 # ╠═c5ec0d58-ce3d-4b0b-a261-dbd37b119f71
 # ╠═b4409687-7bee-4028-824d-03b209aee68d
-# ╠═30e99e77-aad1-43e8-9284-ab0bf8ae741f
+# ╟─30e99e77-aad1-43e8-9284-ab0bf8ae741f
 # ╠═28bcd612-19f6-4e25-b6df-cb43df4f2a73
 # ╠═04e414ab-c790-4d31-b216-18776534a287
 # ╠═54700ad7-6b2a-440f-903a-c126b4c60c0e
-# ╠═767a58ed-9d7b-41db-a488-10f98a777474
+# ╠═aabd7db4-103a-4029-96d3-0de7077d759d
+# ╟─767a58ed-9d7b-41db-a488-10f98a777474
 # ╠═35472e04-e096-4948-a218-3de53923f271
 # ╠═2d0ca6e6-0333-4aec-93d4-43eb9985dc14
 # ╠═6465e51b-8d71-4c85-ba40-e6d230aa53b1
-# ╠═2e04be98-625f-45f4-bf5e-a0074ea1ea01
+# ╟─2e04be98-625f-45f4-bf5e-a0074ea1ea01
+# ╠═987c9e27-b993-4aae-a25e-2a12ffe94ee7
 # ╠═a063cf93-9cd2-4c8b-9c0d-87075d1fa20d
-# ╠═51f266ce-ffca-4ffe-aae5-ab0fa0e16479
-# ╠═8ea6883e-f157-4faf-9409-f91dd2581464
-# ╠═50757759-9ec3-42d0-a765-df212642885a
+# ╟─50757759-9ec3-42d0-a765-df212642885a
 # ╠═5aed77d3-5798-4538-b3eb-3f4ce43d0423
-# ╠═06d2d1a0-883f-4f79-b94d-e4c94647e208
-# ╠═bfef454d-3664-49de-b8ae-10c529f5a64b
-# ╠═cd9e4e56-301d-44b8-b013-9cf9196e7e90
-# ╠═181e3bbd-d95b-4c50-87a9-75f4851e85a1
-# ╠═993f1f74-4a55-47a7-9e3e-c725cba13c0a
+# ╟─993f1f74-4a55-47a7-9e3e-c725cba13c0a
 # ╠═5a6d605d-bff6-4b7d-97f0-ca35750411d3
+# ╠═ccd8dd8e-c361-43ba-b4f1-2444ec6008fc
 # ╠═2b773594-5187-45bc-96f4-22a3d726b7d2
 # ╠═a5b04acc-acc5-4d4d-8871-09d54caab185
-# ╠═425cdd47-c69f-4bd8-9582-97fe6433891c
 # ╠═fb6dc898-21a9-4f8d-aa14-5b45974c2242
-# ╠═9c8aebbe-8606-41e7-8e86-23129b1cbc8d
-# ╠═91279812-9848-48bc-9258-b6f86c9fe923
-# ╠═d995059c-81f7-441c-8695-6ba08c90a1f8
-# ╠═a59d820c-616d-42ff-a0b3-d495d9f529f8
+# ╟─9c8aebbe-8606-41e7-8e86-23129b1cbc8d
+# ╟─91279812-9848-48bc-9258-b6f86c9fe923
 # ╠═a257ce07-efbe-45e1-a8b0-ada40c29de8d
-# ╠═49846128-379c-4c3b-9ec1-567ffa92e079
+# ╟─49846128-379c-4c3b-9ec1-567ffa92e079
 # ╠═4cf596f1-0042-4990-8d0a-caa8ba1db0c7
-# ╠═5700a6c2-d6b1-4506-b776-7ba485262030
-# ╠═ac3407d6-26ed-4aa4-a7c9-40c529205915
+# ╟─71900c43-9f52-474d-adc7-becdc74045da
+# ╠═cd26da77-02fb-4b65-bd7b-88060d0c97e8
+# ╠═10278d0c-8c72-4c5f-b857-d3bc6ff2c242
+# ╠═2c0b4f97-5953-497d-bca9-d1aa46c5150b
+# ╟─7122bd53-81f6-4ea5-a024-86fdd7a7207a
+# ╟─080c1bca-afcd-46c0-80b8-1708e8d05ae6
+# ╠═f26f6b6b-27f5-4372-b214-d1515c8c0ddc
+# ╟─e24c231a-0bf3-4a03-a307-2ab43cdbecf4
+# ╠═21ffd833-428f-488d-8df3-e8468aa76bb6
+# ╟─dfaab7c1-84be-421d-9eb3-60235a2b2a17
+# ╠═a59e371a-b671-4648-984d-7bcaac367d32
+# ╟─d26e224a-dc89-407d-9451-6665321154a2
+# ╠═b5cd8b13-e3db-4ed1-80ce-e3ac1c57932c
+# ╠═a53a78b3-dcbe-4b62-a336-a26e647dc8c8
+# ╠═f0c02e4a-c0cc-41de-b1bf-f5fad7e7dfdb
+# ╟─c045caa6-a44d-4a54-b122-1e50b1e0fe75

--- a/docs/src/getting-started/tutorials/fitting-dists-with-Turing.jl
+++ b/docs/src/getting-started/tutorials/fitting-dists-with-Turing.jl
@@ -58,7 +58,7 @@ We'll start by simulating some censored and truncated delay distribution data. W
 """
 
 # ╔═╡ b4409687-7bee-4028-824d-03b209aee68d
-Random.seed!(1234) # Set seed for reproducibility
+Random.seed!(123) # Set seed for reproducibility
 
 # ╔═╡ 30e99e77-aad1-43e8-9284-ab0bf8ae741f
 md"Define the parameters for the simulation"

--- a/docs/src/getting-started/tutorials/fitting-dists-with-Turing.jl
+++ b/docs/src/getting-started/tutorials/fitting-dists-with-Turing.jl
@@ -7,7 +7,7 @@ using InteractiveUtils
 # ╔═╡ bb9c75db-6638-48fe-afcb-e78c4bcc057d
 begin
     let
-        docs_dir = dirname(dirname(@__DIR__))
+        docs_dir = (dirname ∘ dirname ∘ dirname)(@__DIR__)
         println(docs_dir)
         using Pkg: Pkg
         Pkg.activate(docs_dir)
@@ -319,7 +319,7 @@ We see that the model has converged and the diagnostics look good. We also see t
 # ╟─30511a27-984e-40b7-9b1e-34bc87cb8d56
 # ╟─bb9c75db-6638-48fe-afcb-e78c4bcc057d
 # ╠═3690c122-d630-4fd0-aaf2-aea9226df086
-# ╠═c5ec0d58-ce3d-4b0b-a261-dbd37b119f71
+# ╟─c5ec0d58-ce3d-4b0b-a261-dbd37b119f71
 # ╠═b4409687-7bee-4028-824d-03b209aee68d
 # ╟─30e99e77-aad1-43e8-9284-ab0bf8ae741f
 # ╠═28bcd612-19f6-4e25-b6df-cb43df4f2a73


### PR DESCRIPTION
This closes issue #38.

I've redone the vignette on fitting censored observations to match https://cdcgov.github.io/Rt-without-renewal/dev/getting-started/tutorials/censored-obs/ but with functions from `PrimaryCensored.jl` as well as added the tutorial to the `/docs/pages.jl` index of pages to generate for `Documenter`.