### PR TITLE
Issue 40: Update make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,6 @@
+using Pkg: Pkg
+Pkg.instantiate()
+
 using Documenter
 using PrimaryCensored
 using Pluto: Configuration.CompilerOptions


### PR DESCRIPTION
This PR closes #40 .

This is a small PR since most of completing #40 was covered by #39 .

The only change here is that the `docs/make.jl` script _also_ instantiates the `docs` environment. This is an IMO harmless duplication with the instantiation step in the documenter CI workflow, but it means that local building (e.g. for local dev)

> `julia --project=docs docs/make.jl` 

from the CL now builds without needing to set-up a `Manifest.toml` file beforehand.

**Points to consider**:

- I'm open to this PR being unnecessary.
- Since #37 Pluto notebooks will only run with `julia-1.11`, which is related to the build of the docs. Should this be flagged?