### PR TITLE
Issue 43: Add helper functions to fitting distributions vignette

### DIFF
--- a/docs/src/getting-started/tutorials/fitting-dists-with-Turing.jl
+++ b/docs/src/getting-started/tutorials/fitting-dists-with-Turing.jl
@@ -92,8 +92,8 @@ md"Let's generates all the $n$ samples by recreating the primary censored sampli
 
 # ╔═╡ a063cf93-9cd2-4c8b-9c0d-87075d1fa20d
 samples = map(pwindows, swindows, obs_times) do pw, sw, ot
-	cens_dist = primarycensored(true_dist, Uniform(0.0, pw)) |>
-                d ->  ot < Inf ? truncated(d; upper =  ot) : d
+    cens_dist = primarycensored(true_dist, Uniform(0.0, pw)) |>
+                d -> ot < Inf ? truncated(d; upper = ot) : d
     within_interval_rand(cens_dist, sw)
 end
 
@@ -208,9 +208,9 @@ summarize(naive_fit)
 # ╔═╡ 2c0b4f97-5953-497d-bca9-d1aa46c5150b
 let
     f = pairplot(naive_fit)
-	CairoMakie.vlines!(f[1, 1], [meanlog], linewidth = 3, color = :red)
+    CairoMakie.vlines!(f[1, 1], [meanlog], linewidth = 3, color = :red)
     CairoMakie.vlines!(f[2, 2], [sdlog], linewidth = 3, color = :red)
-	CairoMakie.scatter!(f[2, 1], [meanlog], [sdlog], markersize = 10, color = :red)
+    CairoMakie.scatter!(f[2, 1], [meanlog], [sdlog], markersize = 10, color = :red)
     f
 end
 
@@ -244,7 +244,7 @@ We make a new `Turing` model that now uses `within_interval_logpmf` rather than 
     dist = LogNormal(mu, sigma)
 
     for i in eachindex(y)
-		censoreddist = truncated(primarycensored(dist, Uniform(0.0, pws[i])); upper=Ds[i])
+        censoreddist = truncated(primarycensored(dist, Uniform(0.0, pws[i])); upper = Ds[i])
         Turing.@addlogprob! n[i] * within_interval_logpmf(censoreddist, y[i], y_upper[i])
     end
 end
@@ -278,7 +278,7 @@ let
     f = pairplot(primarycensoreddist_fit)
     CairoMakie.vlines!(f[1, 1], [meanlog], linewidth = 3, color = :red)
     CairoMakie.vlines!(f[2, 2], [sdlog], linewidth = 3, color = :red)
-	CairoMakie.scatter!(f[2, 1], [meanlog], [sdlog], markersize = 10, color = :red)
+    CairoMakie.scatter!(f[2, 1], [meanlog], [sdlog], markersize = 10, color = :red)
     f
 end
 

--- a/src/PrimaryCensored.jl
+++ b/src/PrimaryCensored.jl
@@ -9,11 +9,13 @@ using Integrals
 # Exported constructors
 export primarycensored, within_interval_censored
 
+# Exported interval functions
+export within_interval_pmf, within_interval_logpmf, within_interval_rand
+
 # Exported special case CDF/PMF functions
 export censored_cdf, censored_pmf
 
 include("docstrings.jl")
-
 include("PrimaryCensoredDist.jl")
 include("censored_pmf.jl")
 include("WithinIntervalCensored.jl")

--- a/src/WithinIntervalCensored.jl
+++ b/src/WithinIntervalCensored.jl
@@ -1,4 +1,31 @@
 @doc raw"
+Calculate the probability mass function (PMF) of a univariate distribution `dist` having a value in the interval `[lower, upper]`.
+"
+function within_interval_pmf(dist::UnivariateDistribution, lower::Real, upper::Real)
+    return cdf(dist, upper) - cdf(dist, lower)
+end
+
+@doc raw"
+Calculate the log probability mass function (log(PMF)) of a univariate distribution `dist` having a value in the interval `[lower, upper]`.
+"
+function within_interval_logpmf(dist::UnivariateDistribution, lower::Real, upper::Real)
+    return log(within_interval_pmf(dist, lower, upper))
+end
+
+@doc raw"
+Generate a random value from a univariate distribution `d` but only return the value within an
+interval of size `swindow`.
+"
+function within_interval_rand(rng::AbstractRNG, d::UnivariateDistribution, swindow::Real)
+    return (rand(rng, d) ÷ swindow) * swindow
+end
+
+function within_interval_rand(d::UnivariateDistribution, swindow::Real)
+    rng = Random.GLOBAL_RNG
+    return (rand(rng, d) ÷ swindow) * swindow
+end
+
+@doc raw"
 Implement a censoring function.
 
 Takes a UnivariateDistribution and returns a WithinIntervalCensored object but depends only on the cdf method.

--- a/test/WithinIntervalCensored.jl
+++ b/test/WithinIntervalCensored.jl
@@ -37,3 +37,33 @@ end
     @test pdf(use_dist_censored) > 0.99
     @test logpdf(use_dist_censored) < 0.0
 end
+
+@testitem "within_interval PMF tests" begin
+    using Distributions
+    dist = Normal(0, 1)
+    lower = -1.0
+    upper = 1.0
+
+    # Calculate the expected value using the CDF
+    expected_value = cdf(dist, upper) - cdf(dist, lower)
+
+    # Test the within_interval_pmf function
+    @test within_interval_pmf(dist, lower, upper) ≈ expected_value
+
+    # Additional test cases
+    lower = 0.0
+    upper = 2.0
+    expected_value = cdf(dist, upper) - cdf(dist, lower)
+    @test within_interval_pmf(dist, lower, upper) ≈ expected_value
+
+    lower = -2.0
+    upper = 0.0
+    expected_value = cdf(dist, upper) - cdf(dist, lower)
+    @test within_interval_pmf(dist, lower, upper) ≈ expected_value
+
+    # Calculate expected logpmf
+    expected_logpmf = log(cdf(dist, upper) - cdf(dist, lower))
+
+    # Test within_interval_logpmf function
+    @test within_interval_logpmf(dist, lower, upper) ≈ expected_logpmf
+end


### PR DESCRIPTION
This PR closes #43 

## Contributions

- I've brought the helper functions used inside the fitting distributions vignette into `src`. I've not found it necessary to use `WithinIntervalCensored` struct, so I've avoided the extra construct step. It _might_ be we can do without this type, but I'm open to push back here. The helper functions replicate the dispatched methods.
- I've updated the fitting distribution vignette to use the new functions.